### PR TITLE
feat: add SearchBar & pagination

### DIFF
--- a/src/features/Courses/ClassesPage/index.jsx
+++ b/src/features/Courses/ClassesPage/index.jsx
@@ -8,9 +8,12 @@ import { ArrowBack } from '@edx/paragon/icons';
 import { extractLastPathSegment } from 'helpers';
 import { RequestStatus } from 'features/constants';
 import TableLayout from 'features/Courses/TableLayout';
+import TableFilters from 'features/Courses/TableFilters';
 import { columns } from 'features/Courses/ClassesPage/columns';
 import { fetchCourseClassesData, fetchCoursesData } from 'features/Courses/data';
 import useManageTableSelection from 'features/Courses/hooks/useManageTableSelection';
+import useFilterSearch from 'features/Courses/hooks/useFilterSearch';
+import TableFooter from 'features/Courses/TableFooter';
 
 const ClassesPage = () => {
   const dispatch = useDispatch();
@@ -38,6 +41,16 @@ const ClassesPage = () => {
     launchId, courseId, tableData: classesTable, fetchData: fetchCourseClassesData,
   });
 
+  const {
+    handleSetKeyword,
+    handleResetSearch,
+    handleFetchDataFromPage,
+    handleSubmitSearch,
+    searchParams,
+  } = useFilterSearch({
+    launchId, courseId, tableData: classesTable, fetchData: fetchCourseClassesData,
+  });
+
   return (
     <>
       {/* eslint-disable react/no-danger */}
@@ -52,16 +65,27 @@ const ClassesPage = () => {
         </div>
         <div className="page-content-container p-4 d-flex flex-column">
           <h3 className="mb-4">{masterCourse?.title}</h3>
+          <TableFilters
+            keyword={searchParams.keyword}
+            handleSetKeyword={handleSetKeyword}
+            handleResetSearch={handleResetSearch}
+            handleSubmitSearch={handleSubmitSearch}
+          />
+
           <TableLayout
             data={classesTable.data}
             columns={columns}
-            count={classesTable.count}
-            numPages={classesTable.numPages}
             handleChangeSelectedCourses={handleChangeSelectedCourses}
             isLoading={classesTable.status === RequestStatus.LOADING}
           />
 
-          <Button className="align-self-end" onClick={handleSubmitSelectedCourses} disabled={!hasSelectedCourses}>
+          <TableFooter
+            numPages={classesTable.numPages}
+            currentPage={searchParams.page}
+            handleFetchDataFromPage={handleFetchDataFromPage}
+          />
+
+          <Button className="align-self-end mt-4" onClick={handleSubmitSelectedCourses} disabled={!hasSelectedCourses}>
             Submit
           </Button>
         </div>

--- a/src/features/Courses/CoursesPage/index.jsx
+++ b/src/features/Courses/CoursesPage/index.jsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Button, Container } from '@edx/paragon';
 import { useHistory, useParams } from 'react-router-dom';
@@ -6,10 +7,12 @@ import DOMPurify from 'dompurify';
 import { extractLastPathSegment } from 'helpers';
 import { fetchCoursesData } from 'features/Courses/data';
 import { RequestStatus } from 'features/constants';
+import TableFilters from 'features/Courses/TableFilters';
 import TableLayout from 'features/Courses/TableLayout';
 import { columns } from 'features/Courses/CoursesPage/columns';
 import useManageTableSelection from 'features/Courses/hooks/useManageTableSelection';
-import { useEffect } from 'react';
+import useFilterSearch from 'features/Courses/hooks/useFilterSearch';
+import TableFooter from 'features/Courses/TableFooter';
 
 const CoursesPage = () => {
   const dispatch = useDispatch();
@@ -28,6 +31,16 @@ const CoursesPage = () => {
     handleSubmitSelectedCourses,
     hasSelectedCourses,
   } = useManageTableSelection({
+    launchId, tableData: table, fetchData: fetchCoursesData,
+  });
+
+  const {
+    handleSetKeyword,
+    handleResetSearch,
+    handleFetchDataFromPage,
+    handleSubmitSearch,
+    searchParams,
+  } = useFilterSearch({
     launchId, tableData: table, fetchData: fetchCoursesData,
   });
 
@@ -53,17 +66,28 @@ const CoursesPage = () => {
       <Container size="xl" className="px-4 pt-3">
         <h2 className="title-page mt-3 mb-3">Courses</h2>
         <div className="page-content-container p-4 d-flex flex-column">
+          <TableFilters
+            keyword={searchParams.keyword}
+            handleSetKeyword={handleSetKeyword}
+            handleResetSearch={handleResetSearch}
+            handleSubmitSearch={handleSubmitSearch}
+          />
+
           <TableLayout
             data={table.data}
             columns={columns}
-            count={table.count}
-            numPages={table.numPages}
             handleChangeSelectedCourses={handleChangeSelectedCourses}
             isLoading={table.status === RequestStatus.LOADING}
             actionButton={actionButton}
           />
 
-          <Button className="align-self-end" onClick={handleSubmitSelectedCourses} disabled={!hasSelectedCourses}>
+          <TableFooter
+            numPages={table.numPages}
+            currentPage={searchParams.page}
+            handleFetchDataFromPage={handleFetchDataFromPage}
+          />
+
+          <Button className="align-self-end mt-4" onClick={handleSubmitSelectedCourses} disabled={!hasSelectedCourses}>
             Submit
           </Button>
         </div>

--- a/src/features/Courses/TableFilters/index.jsx
+++ b/src/features/Courses/TableFilters/index.jsx
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+import PropTypes from 'prop-types';
+import { Form, Icon } from '@edx/paragon';
+import { Button } from 'react-paragon-topaz';
+import { Search } from '@edx/paragon/icons';
+
+const TableFilters = ({
+  handleSetKeyword, handleResetSearch, keyword, handleSubmitSearch,
+}) => {
+  const [currentSearchedKeyword, setCurrentSearchedKeyword] = useState('');
+  return (
+    <div>
+      <Form onSubmit={(event) => {
+        setCurrentSearchedKeyword(keyword);
+        handleSubmitSearch(event);
+      }}
+      >
+        <Form.Row className="col-12 ">
+          <Form.Group className="col m-0" size="lg">
+            <Form.Control
+              leadingElement={<Icon src={Search} size="lg" />}
+              value={keyword}
+              onChange={(e) => handleSetKeyword(e.target.value)}
+            />
+          </Form.Group>
+          <div className="d-flex">
+            <Button
+              className="mr-2"
+              onClick={() => {
+                handleResetSearch();
+                setCurrentSearchedKeyword('');
+              }}
+              variant="subtle"
+            >
+              Reset
+            </Button>
+            <Button
+              disabled={!keyword || keyword === currentSearchedKeyword}
+              variant="outline-primary"
+              type="submit"
+            >
+              Apply
+            </Button>
+          </div>
+        </Form.Row>
+      </Form>
+    </div>
+  );
+};
+
+TableFilters.propTypes = {
+  handleSetKeyword: PropTypes.func.isRequired,
+  handleResetSearch: PropTypes.func.isRequired,
+  handleSubmitSearch: PropTypes.func.isRequired,
+  keyword: PropTypes.string,
+};
+
+TableFilters.defaultProps = {
+  keyword: '',
+};
+
+export default TableFilters;

--- a/src/features/Courses/TableFooter/index.jsx
+++ b/src/features/Courses/TableFooter/index.jsx
@@ -1,0 +1,36 @@
+import PropTypes from 'prop-types';
+import { Pagination } from '@edx/paragon';
+
+const TableFooter = ({
+  numPages,
+  currentPage,
+  handleFetchDataFromPage,
+}) => {
+  if (numPages === 1) { return null; }
+  return (
+    <div className="d-flex justify-content-end align-items-center">
+      <div className=" mr-5">Page {currentPage} of {numPages}</div>
+      <Pagination
+        paginationLabel="pagination navigation"
+        pageCount={numPages}
+        currentPage={currentPage}
+        variant="minimal"
+        onPageSelect={(page) => handleFetchDataFromPage(page)}
+      />
+    </div>
+  );
+};
+
+TableFooter.propTypes = {
+  numPages: PropTypes.number,
+  currentPage: PropTypes.number,
+  handleFetchDataFromPage: PropTypes.func,
+};
+
+TableFooter.defaultProps = {
+  numPages: 0,
+  currentPage: 0,
+  handleFetchDataFromPage: () => {},
+};
+
+export default TableFooter;

--- a/src/features/Courses/TableLayout/index.jsx
+++ b/src/features/Courses/TableLayout/index.jsx
@@ -8,8 +8,6 @@ import './index.scss';
 const TableLayout = ({
   data,
   columns,
-  count,
-  numPages,
   handleChangeSelectedCourses,
   isLoading,
   actionButton,
@@ -18,10 +16,7 @@ const TableLayout = ({
     <Col>
       <DataTable
         isSelectable
-        isPaginated
-        manualPagination
-        itemCount={count}
-        pageCount={numPages}
+        itemCount={data.length}
         onSelectedRowsChanged={handleChangeSelectedCourses}
         isLoading={isLoading}
         columns={columns}
@@ -36,7 +31,6 @@ const TableLayout = ({
       >
         <DataTable.Table />
         <DataTable.EmptyTable content="No courses found." />
-        <DataTable.TableFooter className="table-footer" />
       </DataTable>
     </Col>
   </Row>
@@ -46,16 +40,12 @@ TableLayout.propTypes = {
   data: PropTypes.arrayOf(PropTypes.shape([])),
   columns: PropTypes.arrayOf(PropTypes.shape([])).isRequired,
   handleChangeSelectedCourses: PropTypes.func.isRequired,
-  count: PropTypes.number,
-  numPages: PropTypes.number,
   isLoading: PropTypes.bool,
   actionButton: PropTypes.func,
 };
 
 TableLayout.defaultProps = {
   data: [],
-  count: 0,
-  numPages: 0,
   isLoading: true,
   actionButton: null,
 };

--- a/src/features/Courses/data/api.js
+++ b/src/features/Courses/data/api.js
@@ -4,20 +4,28 @@ import { getConfig } from '@edx/frontend-platform';
 
 const DEEP_LINKING_URL = 'lti/deep_linking';
 
-function fetchLicensedCourses(launchId) {
+function fetchLicensedCourses(launchId, { keyword = '', page = 1, courseId = '' } = {}) {
   const apiV2BaseUrl = getConfig().COURSE_OPERATIONS_API_V2_BASE_URL;
 
   const URL = [apiV2BaseUrl, DEEP_LINKING_URL, launchId, 'content_items/courses'].join('/');
 
-  return getAuthenticatedHttpClient().get(URL);
+  const params = {
+    search: keyword,
+    page,
+    course_id: courseId,
+  };
+
+  return getAuthenticatedHttpClient().get(URL, { params });
 }
 
-function fetchCoursesClasses(launchId, { courseId = '' }) {
+function fetchCoursesClasses(launchId, { keyword = '', page = 1, courseId = '' } = {}) {
   const apiV2BaseUrl = getConfig().COURSE_OPERATIONS_API_V2_BASE_URL;
 
   const URL = [apiV2BaseUrl, DEEP_LINKING_URL, launchId, 'content_items/classes'].join('/');
 
   const params = {
+    search: keyword,
+    page,
     course_id: courseId,
   };
 

--- a/src/features/Courses/data/slice.js
+++ b/src/features/Courses/data/slice.js
@@ -1,11 +1,10 @@
 /* eslint-disable no-param-reassign */
 import { createSlice } from '@reduxjs/toolkit';
 
-import { RequestStatus, initialPage } from 'features/constants';
+import { RequestStatus } from 'features/constants';
 
 const initialState = {
   table: {
-    currentPage: initialPage,
     data: [],
     status: RequestStatus.INITIAL,
     error: null,
@@ -13,7 +12,6 @@ const initialState = {
     count: 0,
   },
   classesTable: {
-    currentPage: initialPage,
     data: [],
     status: RequestStatus.INITIAL,
     error: null,

--- a/src/features/Courses/data/thunk.js
+++ b/src/features/Courses/data/thunk.js
@@ -12,12 +12,26 @@ import {
   updateCourseClassesDataFailed,
 } from 'features/Courses/data/slice';
 
-function fetchCoursesData(launchId) {
+/**
+ * Fetches licensed courses for a specific launch ID.
+ *
+ * Dispatches a request action to update the courses data status to loading.
+ * It then attempts to fetch the courses data using the provided launch ID and parameters.
+ * If successful, it dispatches a success action with the fetched data.
+ * In case of failure, it dispatches a failure action and logs the error.
+ *
+ * @param {string} launchId - The launch ID for the request.
+ * @param {Object} params - Additional parameters for the request.
+ * @param {string} params.courseId - The ID of the course to filter by (optional).
+ * @param {string} params.keyword - A keyword for searching courses (optional).
+ * @returns {Function} A thunk that handles fetching licensed courses data and dispatching actions.
+ */
+function fetchCoursesData(launchId, params) {
   return async (dispatch) => {
     dispatch(updateCoursesDataRequest());
 
     try {
-      const response = camelCaseObject(await fetchLicensedCourses(launchId));
+      const response = camelCaseObject(await fetchLicensedCourses(launchId, params));
       dispatch(updateCoursesDataSuccess(response.data));
     } catch (error) {
       dispatch(updateCoursesDataFailed());
@@ -37,6 +51,7 @@ function fetchCoursesData(launchId) {
  * @param {string} launchId - The launch ID for the request.
  * @param {Object} params - Additional parameters for the request.
  * @param {string} params.courseId - The course ID for which to fetch the classes data.
+ * @param {string} [params.keyword] - A keyword for searching course classes (optional).
  * @returns {Function} A thunk that handles fetching course classes data and dispatching actions.
  */
 function fetchCourseClassesData(launchId, params) {

--- a/src/features/Courses/hooks/useFilterSearch.js
+++ b/src/features/Courses/hooks/useFilterSearch.js
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react';
+import { useDispatch } from 'react-redux';
+
+import { resetCourseClassesData } from 'features/Courses/data/slice';
+import { initialPage } from 'features/constants';
+
+/**
+ * Custom hook for managing search and pagination state in a course list table.
+ *
+ * @param {Object} props - The properties for configuring the hook.
+ * @param {string} props.launchId - The deep linking launch ID.
+ * @param {string} props.courseId - The ID of the course to filter by.
+ * @param {Function} props.fetchData - A thunk that fetches the course list data.
+ * @returns {Object} The search and pagination state, and functions to manipulate them.
+ * @returns {{
+ *   handleSetKeyword: Function,
+ *   handleResetSearch: Function,
+ *   handleSubmitSearch: Function,
+ *   handleFetchDataFromPage: Function,
+ *   searchParams: {
+ *     keyword: string,
+ *     page: number,
+ *   },
+ * }}
+ */
+const useFilterSearch = ({
+  launchId, courseId, fetchData,
+}) => {
+  const dispatch = useDispatch();
+  const [keyword, setKeyword] = useState('');
+  const [page, setPage] = useState(initialPage);
+
+  const handleSetKeyword = (newKeyword) => {
+    setKeyword(newKeyword);
+  };
+
+  const handleResetSearch = () => {
+    if (keyword !== '' || page !== initialPage) {
+      setKeyword('');
+      setPage(initialPage);
+      dispatch(fetchData(launchId, { keyword: '', page: initialPage, courseId }));
+    }
+  };
+
+  const handleFetchDataFromPage = (newPage) => {
+    setPage(newPage);
+  };
+
+  const handleSubmitSearch = (event) => {
+    event.preventDefault();
+    dispatch(fetchData(launchId, { keyword, courseId }));
+  };
+
+  useEffect(() => {
+    dispatch(fetchData(launchId, { page, courseId }));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [page, launchId]);
+
+  useEffect(() => () => {
+    dispatch(resetCourseClassesData());
+  }, [launchId, dispatch]);
+
+  return {
+    handleSetKeyword,
+    handleResetSearch,
+    handleSubmitSearch,
+    handleFetchDataFromPage,
+    searchParams: { keyword, page },
+  };
+};
+
+export default useFilterSearch;


### PR DESCRIPTION
### Ticket

PAD-1547
PAD-1548

### Description

This PR adds pagination and a search bar to filter the table data.

### Main changes made

- [src/features/Courses/TableFilters/index.jsx](https://github.com/Pearson-Advance/frontend-app-lti/pull/9/files#diff-0be3040d8a1c6ce3b66c5831c6879537a65b5b28e9145d7cf321c6513a2c49d1): Component that renders the search bar filter and the buttons to handle the main actions until now
- [src/features/Courses/TableFooter/index.jsx](https://github.com/Pearson-Advance/frontend-app-lti/pull/9/files#diff-dbbdc47f07e05b1fb0b0f53d5d0ac5b8bc79e8ec2a25529c733b2b2e92946ba8): Custom component to add a footer to the table; this contains the specific buttons (with the handlers) and info about the page
- [src/features/Courses/hooks/useFilterSearch.js](https://github.com/Pearson-Advance/frontend-app-lti/pull/9/files#diff-1e0fe82a334d2656b5eabe47a66682b1b010931d5d790e90e90a841f43c95c3e): Custom hook for managing search and pagination state in that tables table. 

### Screenshots

![image](https://github.com/user-attachments/assets/4c6c3fe0-37ca-4f73-bb25-c30bff32aff8)
![image](https://github.com/user-attachments/assets/8e4ca89f-2756-4770-bf54-3fbccb2b0785)
![image](https://github.com/user-attachments/assets/828367a9-ad0e-4031-bd23-2ae3df73d648)

### How to test
- Set the environment to use `Deep Linking`
- Enable CCX in a course and create a Class of that course
- Enable the redirect to the LTI MFE when launching a `Deep Linking Flow`
- Up the LTI MFE 

If everything goes well, once you launch a Deep Linking Flow (I use IMS), you should be redirected to the LTI MFE and watch the courses table with the master courses you created before: if you search by text in the search bar, you should be able to filter the data.

Now, if you click the `View class list` button, you should see a table with the list of classes (CCX) from this specific course. You should be able to filter the data here, as in the previous table.

