### PR TITLE
PADV-3026.2: Fix useNavigate CoursesPage actionButton URL

### DIFF
--- a/src/features/Courses/CoursesPage/index.jsx
+++ b/src/features/Courses/CoursesPage/index.jsx
@@ -36,7 +36,7 @@ const CoursesPage = () => {
     <Button
       variant="outline-primary"
       size="sm"
-      onClick={() => courseId && navigate(`${launchId}/${courseId}`)}
+      onClick={() => courseId && navigate(`/deep_linking/${launchId}/${courseId}`)}
     >
       View class list
     </Button>


### PR DESCRIPTION
### Ticket

https://pearson.atlassian.net/browse/PADV-3026

### Description

This PR fixes the URL used in useNavigate on the actionButton found on the CoursesPage. In a previous PR when React was updated we replaced useHistory with useNavigate, in React Router v5 (useHistory), paths were generally treated as absolute from the root if they didn't look like a relative path, or the logic was less strict about the current location. In React Router v6 (useNavigate), navigation is relative by default to the component's rendered location. This PR solves this issue by correctly setting the useNavigate URL to reach to the ClassesPage.